### PR TITLE
fix: bump deps for protocol and fs bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "greenlock",
-	"version": "2.8.8",
+	"version": "2.8.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "greenlock",
-	"version": "2.8.8",
+	"version": "2.8.9",
 	"description": "Greenlock is Let's Encrypt (ACME) client for node.js",
 	"homepage": "https://greenlock.domains/",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
 	"dependencies": {
 		"acme": "^1.3.5",
 		"acme-dns-01-cli": "^3.0.0",
-		"acme-v2": "^1.8.6",
+		"acme-v2": "^1.8.7",
 		"cert-info": "^1.5.1",
 		"greenlock-store-fs": "^3.0.2",
 		"keypairs": "^1.2.14",
 		"le-challenge-fs": "^2.0.2",
 		"le-sni-auto": "^2.1.9",
-		"le-store-certbot": "^2.2.3",
+		"le-store-certbot": "^2.2.4",
 		"rsa-compat": "^2.0.8"
 	},
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"lib"
 	],
 	"scripts": {
+		"bump": "npm version -m \"chore(release): bump to v%s\"",
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"repository": {


### PR DESCRIPTION
- poll order URL rather than finalize URL to fix difference between draft-12 and RFC8555 deployments
- skip writing `pems.bundle` when it doesn't exist